### PR TITLE
update showjobgpuusage to query scontrol show job -d once per job instead of once per node

### DIFF
--- a/showjobgpuusage
+++ b/showjobgpuusage
@@ -1,41 +1,103 @@
 #!/bin/bash
 
+set -euo pipefail
+
 TARGET_USER=${1:-$USER}
 
 echo "Checking GPU utilization for $TARGET_USER"
 
-# 1. Get Job ID and Node List
-JOBS=$(squeue -u "$TARGET_USER" -t RUNNING --noheader -o "%i|%N")
+# 1. Get Job ID, Node List, and State
+JOBS=$(squeue -u "$TARGET_USER" -t RUNNING,COMPLETING --noheader -o "%i|%N|%T")
 
-Num_Jobs=$(squeue -u jhonnyv19 | wc -l)
+Num_Jobs=$(squeue -u "$TARGET_USER" -t RUNNING,COMPLETING --noheader | wc -l)
 echo "$TARGET_USER has $Num_Jobs jobs"
 
 if [ -z "$JOBS" ]; then
-    echo "No running jobs found."
+    echo "No running or completing jobs found."
     exit 0
 fi
 
-for entry in $JOBS; do
-    JOBID=$(echo $entry | cut -d'|' -f1)
-    NODELIST=$(echo $entry | cut -d'|' -f2)
-    NODES=$(scontrol show hostnames "$NODELIST")
+# expand Slurm-style GPU index ranges into comma-separated values for nvidia-smi
+expand_gpu_ids_for_nvidia_smi() {
+    local raw="$1"
+    local out=()
+    local part
+    IFS=',' read -ra parts <<< "$raw"
+    for part in "${parts[@]}"; do
+        if [[ "$part" =~ ^[0-9]+-[0-9]+$ ]]; then
+            start="${part%-*}"
+            end="${part#*-}"
+            for ((i=start; i<=end; i++)); do
+                out+=("$i")
+            done
+        elif [[ "$part" =~ ^[0-9]+$ ]]; then
+            out+=("$part")
+        fi
+    done
+    local IFS=,
+    echo "${out[*]}"
+}
+
+# parse one scontrol line and store node - GPU_IDX mapping
+parse_job_node_gpu_map() {
+    local jobid="$1"
+    local scontrol_out
+    scontrol_out="$(scontrol show job "$jobid" -d 2>/dev/null || true)"
+
+    while IFS= read -r line; do
+        [[ "$line" == *"Nodes="* ]] || continue
+        [[ "$line" == *"IDX:"* ]] || continue
+
+        nodes_expr="$(echo "$line" | grep -oE 'Nodes=[^ ]+' | cut -d= -f2 || true)"
+        gpu_ids="$(echo "$line" | sed -n 's/.*IDX:\([^)]*\).*/\1/p' | head -n 1 || true)"
+
+        [[ -z "${nodes_expr:-}" ]] && continue
+        [[ -z "${gpu_ids:-}" ]] && continue
+
+        for host in $(scontrol show hostnames "$nodes_expr" 2>/dev/null); do
+            NODE_GPU_IDS["$host"]="$gpu_ids"
+        done
+    done < <(echo "$scontrol_out" | sed -n '/^[[:space:]]*Nodes=/p')
+}
+
+while IFS='|' read -r JOBID NODELIST JOBSTATE; do
+    [ -z "${JOBID:-}" ] && continue
+    [ -z "${NODELIST:-}" ] && continue
+    [ -z "${JOBSTATE:-}" ] && continue
+
+    # If it's a job that is completing, report it and skip GPU query
+    if [[ "$JOBSTATE" == "COMPLETING" || "$JOBSTATE" == "CG" ]]; then
+        echo "------------------------------------------------"
+        echo "JobID: $JOBID  |  NodeList: $NODELIST  |  State: $JOBSTATE"
+        echo "------------------------------------------------"
+        continue
+    fi
+
+    NODES=$(scontrol show hostnames "$NODELIST" 2>/dev/null || true)
+    if [ -z "${NODES:-}" ]; then
+        echo "WARNING: could not expand nodes for JobID $JOBID (NODELIST=$NODELIST)" >&2
+        continue
+    fi
+
+    declare -A NODE_GPU_IDS
+    parse_job_node_gpu_map "$JOBID"
 
     for node in $NODES; do
-        # 2. Extract Slurm's internal GPU IDX (e.g., 0,1)
-        # Using grep to find the IDX specifically for the node in question
-        GPU_IDS=$(scontrol show job "$JOBID" -d | grep "$node" | grep -oP 'IDX:\K[^)]+')
+        GPU_IDS="${NODE_GPU_IDS[$node]:-}"
 
-        if [ -z "$GPU_IDS" ]; then
+        if [ -z "${GPU_IDS:-}" ]; then
             continue
         fi
+
+        GPU_IDS_FOR_NVIDIA_SMI=$(expand_gpu_ids_for_nvidia_smi "$GPU_IDS")
 
         echo "------------------------------------------------"
         echo "JobID: $JOBID  |  Node: $node"
         echo "Slurm Allocated GPU Index: $GPU_IDS"
         echo "------------------------------------------------"
 
-        # 3. Force nvidia-smi to use PCI_BUS_ID order (usually matches Slurm)
-        # and query only the indices provided by Slurm
-        ssh -q -o ConnectTimeout=5 "$node" "export CUDA_DEVICE_ORDER=PCI_BUS_ID; nvidia-smi -i $GPU_IDS --query-gpu=index,utilization.gpu,memory.used,name --format=csv,noheader"
+        if ! ssh -n -q -o ConnectTimeout=5 "$node" "nvidia-smi -i $GPU_IDS_FOR_NVIDIA_SMI --query-gpu=index,utilization.gpu,memory.used,name --format=csv,noheader" < /dev/null; then
+            echo "WARNING: failed to query nvidia-smi for JobID $JOBID on node $node (GPU IDs: $GPU_IDS_FOR_NVIDIA_SMI)" >&2
+        fi
     done
-done
+done <<< "$JOBS"


### PR DESCRIPTION
- update the main job loop from shell word-splitting to while IFS='|' read -r ...
- update squeue to parse job state and helper function to expand Slurm GPU index ranges for nvidia-smi
- support for  multi-node GPU IDX parsing from scontrol show job -d
