### PR TITLE
Remove the .arc_quota/{projects,slurm} file fallback from quota

### DIFF
--- a/quota
+++ b/quota
@@ -34,55 +34,6 @@ usage() {
   "
 }
 
-print_ess_gpfs_quota() {
-    local user=$1
-    local projects_cache="/home/$user/$CACHE_DIR/projects"
-    if [ -s "$projects_cache" ]; then
-        echo
-
-        local last_updated="$(ls -l "$projects_cache" | awk '{print $6, $7, $8}')"
-        json=$(cat "$projects_cache")
-        while read line; do
-            local colors=('' '' '' '' '' '' '')
-            local path=$(echo $line | awk -F\| '{print $1}')
-            local num_fields=$(awk -F\| '{print NF}' <<< "$line")
-
-            # If account is expired
-            if [ "$num_fields" -lt 3 ]; then
-		local row=("$user" "$path" "0" "0" "EXPIRED" "EXPIRED" "$last_updated")
-                print_row row[@] colors[@]
-                continue
-            fi
-
-	    local block_usage_kib=$(echo $line | awk -F\| '{print $2}');
-	    local block_quota_kib=$(echo $line | awk -F\| '{print $3}');
-
-	    local block_usage_gib=$(KiB_to_GB "$block_usage_kib")
-	    local block_quota_gib=$(KiB_to_GB "$block_quota_kib")
-
-	    local files_usage=$(echo $line | awk -F\| '{print $4}');
-	    local files_quota=$(echo $line | awk -F\| '{print $5}');
-
-            local row=("$user" "$path" "$block_usage_gib" "$block_quota_gib" "$files_usage" "$files_quota" "$last_updated")
-            print_row row[@] colors[@]
-
-        done < <(cat "$projects_cache" | python3 <( echo '
-import sys, json
-for k, v in json.load(sys.stdin).items():
-    path = k
-    block_usage = v.get("blockUsage", 0)
-    block_quota = v.get("blockQuota", 0)
-    files_usage = v.get("filesUsage", 0)
-    files_quota = v.get("filesQuota", 0)
-    if block_usage == 0 and block_quota == 0 and files_usage == 0 and files_quota == 0:
-        print(f"{path}|{path}")
-    else:
-        print(f"{path}|{block_usage}|{block_quota}|{files_usage}|{files_quota}")
-'))
-    fi
-}
-
-
 print_home_quota() {
 	local user=$1
 
@@ -105,78 +56,6 @@ print_home_quota() {
 	local colors=('' '' '' '' '' '' '')
 	local row=("$user" "/home" "$usage_GiB" "$limit_GiB" "-" "-" "$last_updated")
 	print_row row[@] colors[@];
-}
-
-print_alloc_quotas() {
-	local user=$1
-
-	print_alloc_header;
-
-	print_alloc_quota "$user" "slurm"
-}
-
-print_alloc_quota() {
-	local user="$1";
-	local alloc_type="$2";
-
-	local json="";
-	local alloc_cache="/home/$user/$CACHE_DIR/$alloc_type";
-	[ -s "$alloc_cache" ] && json=$(cat "$alloc_cache");
-
-	[ -z "$json" ] && return; # skip when response is empty
-
-	while read line; do
-		local pid=$(echo $line | awk -F\| '{print $1}');
-		local alloc=$(echo $line | awk -F\| '{print $2}');
-		local cluster=$(echo $line | awk -F\| '{print $3}');
-		local quota=$(echo $line | awk -F\| '{print $4}');
-		local left=$(echo $line | awk -F\| '{print $5}');
-		local status=$(echo $line | awk -F\| '{print $6}');
-
-		local colors=('' '' '' '' '' '' '')
-
-		local note="";
-		local now_epoch=0;
-		if [ "$status" == "Revoked" ]; then
-			continue;
-		fi
-		if [ "$status" == "Expired" ]; then
-			note+="Allocation has expired. ";
-			colors[1]=${YELLOW};
-			colors[2]=${YELLOW};
-			colors[5]=${YELLOW};
-			colors[6]=${RED};
-		fi
-		if [ "$left" == "0" ]; then
-			note+="Allocation has no funds. ";
-			colors[1]=${YELLOW};
-			colors[2]=${YELLOW};
-			colors[4]=${YELLOW};
-			colors[6]=${RED};
-		fi
-
-		printf "$(print_padding colors[@] 'header')" \
-			"$pid" "$alloc" "$cluster" "$quota" "$left" "$status" "$note";
-
-	done < <(cat "$alloc_cache" | python <( echo '
-from __future__ import print_function;
-import sys, json;
-for (k, v) in json.load(sys.stdin).items(): 
-	i=0;
-	status = ""
-	if "status" in v:
-		status = v["status"];
-	for f in v["funds"]: 
-		alloc = f["allocated"];
-		remain = f["remaining"];
-
-		if i == 0: 
-			print("'$user'"+"|"+k+"|"+f["cluster"]+"|"+alloc+"|"+remain+"|"+status+"|")
-		else:
-			print("||"+f["cluster"]+"|" + alloc+"|"+remain+"|"+status+"|");
-		i += 1;
-'))
-
 }
 
 parse_storage_quota() {
@@ -227,12 +106,6 @@ parse_storage_quota() {
 print_storage_header() {
 	printf "$(print_padding HEADER_COLORS[@] 'header')" \
 		"USER" "FILESYS/SET" "DATA (GB)" "QUOTA (GB)" "FILES" "QUOTA" "LAST UPDATED"
-}
-
-print_alloc_header() {
-	echo;
-	printf "$(print_padding HEADER_COLORS[@] 'header')" \
-		"USER" "ALLOCATION" "CLUSTER" "QUOTA (hrs)" "LEFT (hrs)" "STATUS" "NOTE";
 }
 
 print_row() {
@@ -293,8 +166,13 @@ print_rest_api_quota() {
 	local response=$(curl -sk -w "%{http_code}" "https://coldfront.arc.vt.edu/api/arc/quota/" \
 		-H "Authorization: Token $(cat "/home/$user/$CACHE_DIR/token")" 2>/dev/null)
 	local http_code="${response: -3}"
-	local json="${response:0:-3}"
-	[ "$http_code" != "200" ] && return 1
+	if [ "$http_code" != "200" ]; then
+		local detail="HTTP $http_code"
+		[ -z "$response" ] && detail="no response from server"
+		echo -e "${RED}Error: could not retrieve project storage and compute usage for $user from ColdFront ($detail).${NC}" >&2
+		return 1
+	fi
+	local json="${response%???}"
 	echo "$json" | python3 <(cat <<EOF
 import sys, json
 from datetime import datetime
@@ -413,15 +291,14 @@ main() {
 
         echo -e "${YELLOW}Warning: quota values are not updated in real time and may take a few hours to refresh.${NC}"
 	print_storage_header;
+	local rc=0
 	for user in $user_list; do
 		print_home_quota "$user"
 		echo
-		if ! print_rest_api_quota "$user"; then
-			print_ess_gpfs_quota "$user"
-			print_alloc_quotas "$user"
-		fi
+		print_rest_api_quota "$user" || rc=1
 	done
 
+	return $rc
 }
 
 main "$@"


### PR DESCRIPTION
Removes the `.arc_quota` file-reading fallback for `projects` and `slurm` from the `quota` script, leaving `/api/arc/quota/` as the sole source for project storage and compute usage.

Closes #29.

## Why

Both ColdFront cron writers this fallback depended on have been removed — `update_project_quota_cache` (which wrote `projects`) and `update_recent_job_acct_quota_cache` (which wrote `slurm`). The leftover files are deliberately **not** being cleaned up, so the fallback would keep finding readable, ever-more-stale data indefinitely rather than eventually erroring out on a missing file. On any API hiccup the script silently printed stale project and compute numbers. Removing the readers is the only thing that actually stops that.

## Changes

Removed:

| Function | Read |
|---|---|
| `print_ess_gpfs_quota()` | `.arc_quota/projects` |
| `print_alloc_quotas()` | `.arc_quota/slurm` |
| `print_alloc_quota()` | `.arc_quota/slurm` |
| `print_alloc_header()` | — dead once `print_alloc_quotas()` went; the REST path prints its own compute header inline |

`print_rest_api_quota()` no longer acts as a fallback trigger: a non-200 prints a red error to **stderr** and returns 1, and `main()` propagates that as a non-zero exit status so callers can detect the failure.

## Drive-by fix

Testing the failure path turned up a fatal bug in it. When `curl` fails outright — DNS failure, connection refused, i.e. the most likely hiccup — the response is empty, and the pre-existing `${response:0:-3}` is a *fatal* bash expansion error. The script died with `substring expression < 0` rather than any usable message, which defeats the whole point of this change.

Fixed by checking the HTTP code *before* slicing the body, and slicing with `${response%???}`, which is safe on short input. Total failure now reports `no response from server`.

## Not touched

`.arc_quota/token` and `print_home_quota()` are unchanged. `home` is still written daily by `refresh_all_home_quota_caches`, and the Qumulo home quota is not an allocation, so the endpoint has nothing to serve in its place. Removing that reader is blocked on adding home quota to the endpoint, tracked separately on the ColdFront side.

## Testing

Exercised with a stubbed `curl` — no live endpoint contacted:

| Case | Result |
|---|---|
| HTTP 503 | visible error on stderr, exit 1, stdout clean |
| `curl` total failure (empty output) | visible error on stderr, exit 1, no crash |
| HTTP 200 | body parsed intact, unchanged |

`bash -n` passes under both bash 3.2 and 5.3.

## Reviewer notes

- Acceptance item 5 from #29 — *confirm nothing else on the login nodes reads `.arc_quota/{projects,slurm}`* — is verified repo-wide (`quota` is the only file referencing `.arc_quota`), but still needs a grep on the login nodes themselves before this is deployed.
- `parse_storage_quota()` has no callers and is now the only remaining user of `KiB_to_GB`. Dead before this change and dead after, so left alone — happy to remove it separately if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
