### PR TITLE
Read /home quota from the ColdFront REST API

### DIFF
--- a/quota
+++ b/quota
@@ -35,26 +35,51 @@ usage() {
 }
 
 print_home_quota() {
-	local user=$1
+	local user="$1"
 
-	local json="";
-	local home_cache="/home/$user/$CACHE_DIR/home";
-	local last_updated="";
-	if [ -s "$home_cache" ]; then
-		json=$(cat "$home_cache");
-		last_updated="$(ls -l "$home_cache" | awk '{print $6, $7, $8}')"
+	local response=$(curl -sk -w "%{http_code}" "https://coldfront.arc.vt.edu/api/arc/quota/home/" \
+		-H "Authorization: Token $(cat "/home/$user/$CACHE_DIR/token")" 2>/dev/null)
+	local http_code="${response: -3}"
+	if [ "$http_code" == "404" ]; then
+		echo -e "${YELLOW}No /home quota on record for $user.${NC}"
+		return 0
+	fi
+	if [ "$http_code" != "200" ]; then
+		local detail="HTTP $http_code"
+		[ -z "$response" ] && detail="no response from server"
+		echo -e "${RED}Error: could not retrieve /home usage for $user from ColdFront ($detail).${NC}" >&2
+		return 1
+	fi
+	local json="${response%???}"
+
+	local home=$(echo "$json" | python3 <(cat <<'EOF'
+import sys, json
+from datetime import datetime
+
+quota = json.load(sys.stdin)
+usage = quota.get("capacity_usage") or 0
+limit = quota.get("limit") or 0
+modified = quota.get("modified")
+last_updated = ""
+if modified:
+    last_updated = datetime.fromisoformat(modified.replace("Z", "+00:00")).strftime("%b %-d %H:%M")
+print(f"{usage}|{limit}|{last_updated}")
+EOF
+) 2>/dev/null)
+	if [ -z "$home" ]; then
+		echo -e "${RED}Error: could not parse the /home usage returned for $user by ColdFront.${NC}" >&2
+		return 1
 	fi
 
-	[ -z "$json" ] && return; # skip when response is empty
+	local usage_bytes=$(echo "$home" | awk -F\| '{print $1}')
+	local limit_bytes=$(echo "$home" | awk -F\| '{print $2}')
+	local last_updated=$(echo "$home" | awk -F\| '{print $3}')
 
-	local usabe_bytes=$(echo "$json" | grep -o 'capacity_usage": "[0-9]\+"' | grep -o "[0-9]\+")
-	local limit_bytes=$(echo "$json" | grep -o 'limit": "[0-9]\+"' | grep -o "[0-9]\+")
-
-	local usage_GiB=$(bytes_to_GB "$usabe_bytes")
-	local limit_GiB=$(bytes_to_GB "$limit_bytes")
+	local usage_GB=$(bytes_to_GB "$usage_bytes")
+	local limit_GB=$(bytes_to_GB "$limit_bytes")
 
 	local colors=('' '' '' '' '' '' '')
-	local row=("$user" "/home" "$usage_GiB" "$limit_GiB" "-" "-" "$last_updated")
+	local row=("$user" "/home" "$usage_GB" "$limit_GB" "-" "-" "$last_updated")
 	print_row row[@] colors[@];
 }
 
@@ -293,7 +318,7 @@ main() {
 	print_storage_header;
 	local rc=0
 	for user in $user_list; do
-		print_home_quota "$user"
+		print_home_quota "$user" || rc=1
 		echo
 		print_rest_api_quota "$user" || rc=1
 	done


### PR DESCRIPTION
Closes #33.

`print_home_quota()` read `/home/$user/.arc_quota/home`, the last `.arc_quota` data file the script still used. It now calls `GET https://coldfront.arc.vt.edu/api/arc/quota/home/`, following `print_rest_api_quota()` for the curl invocation, the `%{http_code}` handling and the token header. The output row is unchanged: `user`, `/home`, usage GB, limit GB, `-`, `-`, last-updated.

The three details from the issue:

- **Unquoted JSON numbers.** The old parser grepped for `capacity_usage": "[0-9]\+"` — the quoted values Qumulo wrote into the cache file. DRF serializes these from integer columns, so they come back unquoted and that grep would match nothing. The response is parsed in an embedded `python3` block instead.
- **`last_updated`** now comes from the endpoint's `modified` (when the row was actually refreshed), not the cache file's mtime, and no longer depends on a file existing. Formatted `%b %-d %H:%M`, matching the `/projects` rows.
- **Failures are visible.** The old `[ -z "$json" ] && return` silently dropped the `/home` row. Now: `404` prints `No /home quota on record for <user>.` in yellow and exits 0 (normal — no Qumulo home quota, or the nightly refresh has not reached the user); any other non-200, including a curl failure with no response, prints a red error to stderr and makes `quota` exit non-zero, as `print_rest_api_quota()` does. A malformed 200 body gets the same treatment rather than a traceback.

`.arc_quota/token` is untouched — it is the API credential — and it is now the only `.arc_quota` path left in the script. Nothing else in this repo references `.arc_quota`.

## Ordering

Per the issue this is step 2, and its blocker — [ARC/coldfront!124](https://code.vt.edu/ARC/coldfront/-/merge_requests/124) — is merged, so this is unblocked. Next is step 3, rolling the new `quota` out to the login nodes; ColdFront keeps writing `.arc_quota/home` until then (step 4), so the file going away is not a concern for deployed copies.

## Testing

Exercised `print_home_quota()` against a stubbed curl for six responses — 200 normal, 404, 500, empty (curl failure), 200 with `"modified": null`, and a malformed 200 body:

| Case | Output | Exit |
|---|---|---|
| 200 normal | `testuser  /home  1.1  644  -  -  Aug 18 04:00` | 0 |
| 404 | `No /home quota on record for testuser.` | 0 |
| 500 | `Error: could not retrieve /home usage for testuser from ColdFront (HTTP 500).` | 1 |
| empty response | `... (no response from server).` | 1 |
| `modified: null` | row prints, last-updated blank | 0 |
| malformed body | `Error: could not parse the /home usage returned for testuser by ColdFront.` | 1 |

Also verified against the live endpoint (post-`!124`), which returns unquoted numbers and a `modified` with microseconds and a real offset rather than the `Z` in the issue's example:

```
{"pid":"nml5566","path":"/home/nml5566/","capacity_usage":14925651968,
 "limit":640000000000,"modified":"2026-08-19T17:10:11.312637-04:00"}
```

Fed through `print_home_quota()` that renders:

```
USER            FILESYS/SET       DATA (GB)   QUOTA (GB)  FILES  QUOTA  LAST UPDATED
nml5566         /home             14.9        640         -      -      Aug 19 17:10
```

matching the numbers in that user's `.arc_quota/home` (`14925352960` / `640000000000`). The offset form parses without a change — `fromisoformat` takes microseconds plus offset, and since the offset is local the column needs no conversion, same as the `/projects` rows.

**Precondition for step 3:** before this reaches the login nodes, the `home` rows need to be populated for *all* users, not just refreshed ad hoc. Immediately after `!124` merged this endpoint returned `404 {"detail":"No home quota on record."}` for a user whose `.arc_quota/home` held a valid quota; a manual refresh fixed that one account. Rolling out while other accounts are still unpopulated would replace their `/home` row with "No /home quota on record" — which looks like a normal empty result, not a failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

